### PR TITLE
task: handle different cols for translation extraction

### DIFF
--- a/lib/cure/database.rb
+++ b/lib/cure/database.rb
@@ -62,8 +62,13 @@ module Cure
       @database.from(:variables).where(name: property_name).get(:value)
     end
 
-    def find_translation(source_value)
-      @database.from(:translations).where(source_value: source_value).get(:value)
+    def find_translation(source_value, from_columns:)
+      query = @database.from(:translations).where(source_value: source_value)
+      if from_columns.is_a?(Array) && !from_columns.empty?
+        query = query.where(column: from_columns)
+      end
+
+      query.get(:value)
     end
 
     def all_translations

--- a/lib/cure/strategy/history/history_cache.rb
+++ b/lib/cure/strategy/history/history_cache.rb
@@ -12,16 +12,21 @@ module Cure
       HistoryCache.instance
     end
 
+    # @param [String, nil] _source_column
+    # @param [String, nil] source_value
     # @return [String]
-    def retrieve_history(source_value)
-      history.search(source_value) unless source_value.nil? || source_value == ""
+    def retrieve_history(_source_column, source_value, from_columns: [])
+      return if source_value.nil? || source_value == ""
+
+      history.search(source_value, from_columns: from_columns)
     end
 
-    # @param [String] source_value
-    # @param [String] value
-    def store_history(source_value, value)
+    # @param [String, nil] source_column
+    # @param [String, nil] source_value
+    # @param [String, nil] generated_value
+    def store_history(source_column, source_value, generated_value)
       unless source_value.nil? || source_value == ""
-        history.insert(source_value, value)
+        history.insert(source_value, generated_value, column: source_column)
       end
     end
 
@@ -43,8 +48,8 @@ module Cure
       end
 
       # @return [String]
-      def search(source_value, _named_range: nil, _column: nil)
-        database_service.find_translation(source_value)
+      def search(source_value, _named_range: nil, from_columns: nil)
+        database_service.find_translation(source_value, from_columns: from_columns)
       end
 
       def insert(source_value, value, named_range: nil, column: nil)

--- a/lib/cure/transformation/candidate.rb
+++ b/lib/cure/transformation/candidate.rb
@@ -30,7 +30,11 @@ module Cure
 
       attr_reader :ignore_empty
 
-      def initialize(column, named_range: Cure::Extraction.default_named_range, options: {})
+      def initialize(
+        column,
+        named_range: Cure::Extraction.default_named_range,
+        options: {}
+      )
         @column = column
         @named_range = named_range
         @ignore_empty = options.fetch(:ignore_empty, false)
@@ -39,21 +43,22 @@ module Cure
         @no_match_translation = nil
       end
 
-      # @param [String, Nil] source_value
+      # @param [String,nil] source_value
       # @param [RowCtx] row_ctx
+      #
       # @return [String,nil]
       # Transforms the existing value
       def perform(source_value, row_ctx)
         value = source_value
 
         @translations.each do |translation|
-          temp = translation.extract(value, row_ctx)
+          temp = translation.extract(@column, value, row_ctx)
           value = temp if temp
         end
 
         if value == source_value && @no_match_translation
           log_trace("No translation made for #{value} [#{source_value}]")
-          value = @no_match_translation.extract(source_value, row_ctx)
+          value = @no_match_translation.extract(@column, source_value, row_ctx)
           log_trace("Translated to #{value} from [#{source_value}]")
         end
 
@@ -87,10 +92,11 @@ module Cure
         @generator = generator
       end
 
-      # @param [String] source_value
+      # @param [String] source_column
+      # @param [String,nil] source_value
       # @return [String]
-      def extract(source_value, row_ctx)
-        @strategy.extract(source_value, row_ctx, @generator)
+      def extract(source_column, source_value, row_ctx)
+        @strategy.extract(source_column, source_value, row_ctx, @generator)
       end
     end
   end

--- a/lib/cure/transformation/transform.rb
+++ b/lib/cure/transformation/transform.rb
@@ -36,7 +36,11 @@ module Cure
           existing_value = row[column]
           next if existing_value.nil? && candidate.ignore_empty
 
-          new_value = candidate.perform(existing_value, RowCtx.new(row, original_row: original_row)) # transform value
+          # transform value
+          new_value = candidate.perform(
+            existing_value,
+            RowCtx.new(row, original_row: original_row)
+          )
           row[column] = new_value
         end
 

--- a/spec/cure/e2e/input/simple_translations.csv
+++ b/spec/cure/e2e/input/simple_translations.csv
@@ -1,0 +1,3 @@
+id,fav_fruit,fav_colour,fav_fruit_2,fav_colour_2,fav_fruit_3,fav_colour_3
+1,banana,red,banana,red,banana,red
+2,banana,blue,banana,blue,banana,blue

--- a/spec/cure/e2e/simple_translations_spec.rb
+++ b/spec/cure/e2e/simple_translations_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "json"
+require "cure/coordinator"
+require "cure/database"
+require "cure/log"
+
+require "fileutils"
+
+# This tests named ranges, variables, adding columns, inserting values, transforms, no nulls in columns.
+RSpec.describe Cure::Coordinator do
+  context "Process entire AWS file" do
+    describe "#extract" do
+      it "will extract required sections" do
+        main = Cure::Launcher.new.with_csv_file(
+          :pathname,
+          Pathname.new("spec/cure/e2e/input/simple_translations.csv")
+        ).with_config do
+          transform do
+            candidate column: "fav_fruit" do
+              with_translation {
+                replace("full").with("proc", execute: ->(val, _ctx) { val[0..3] })
+              }
+            end
+
+            candidate column: "fav_fruit_2" do
+              with_translation {
+                replace("full", force_replace: true).with("proc", execute: ->(val, _ctx) { val[3..-1] })
+              }
+            end
+
+            candidate column: "fav_fruit_3" do
+              with_translation {
+                replace("full", accept_translations_from: ["fav_fruit"]).with("proc", execute: ->(val, _ctx) { val[3..-1] })
+              }
+            end
+          end
+
+          export do
+            terminal title: "Preview", limit_rows: 20
+            # csv file_name: "invoice", directory: "/tmp/cure", named_range: "items"
+          end
+        end
+
+        main.setup
+
+        coordinator = Cure::Coordinator.new
+        coordinator.process
+
+        # file_one = "/tmp/cure/invoice.csv"
+        # expect(File.exist? file_one).to eq(true)
+        #
+        # expected_file = "spec/cure/e2e/output/invoice_output.csv"
+        # expect(FileUtils.compare_file(file_one, expected_file)).to be_truthy
+      end
+    end
+  end
+end


### PR DESCRIPTION
if a translation or match is made, allow it to be forced to be from columns provided

```ruby
      candidate column: "fav_fruit_3" do
        with_translation {
          replace("full", accept_translations_from: ["your col"]).with("proc", execute: ->(val, _ctx) { val[3..-1] })
        }
      end
```

