### PR TITLE
feat: handle named ranges nicer

### DIFF
--- a/lib/cure/extract/csv_lookup.rb
+++ b/lib/cure/extract/csv_lookup.rb
@@ -4,12 +4,13 @@ module Cure
   module Extract
     class CsvLookup
 
-      # @param [String,Integer] position - [Ex A1:B1, A1:B1,A2:B2]
+      X_MAX_LIMIT = 1_023
+      Y_MAX_LIMIT = 10_000_000
+      \
+      # @param [String,Integer] position - [Ex A1:B1, A1:B1, A2:B2, A:B2, A:B]
       # @return [Array] [column_start_idx, column_end_idx, row_start_idx, row_end_idx]
       def self.array_position_lookup(position)
-        # This is a better way, still trying to figure out a better way but -1 doesn't work for ranges.
-        # return [0, -1, 0, -1] if position.is_a?(Integer) && position == -1
-        return [0, 1_023, 0, 10_000_000] if position.is_a?(Integer) && position == -1 # Whole sheet
+        return [0, X_MAX_LIMIT, 0, Y_MAX_LIMIT] if position.is_a?(Integer) && position == -1 # Whole sheet
 
         start, finish, *_excess = position.split(":")
         raise "Invalid format" unless start || finish
@@ -17,8 +18,8 @@ module Cure
         [
           position_for_letter(start),
           position_for_letter(finish),
-          position_for_digit(start),
-          position_for_digit(finish)
+          position_for_digit(start, if_digit_nil: 0),
+          position_for_digit(finish, if_digit_nil: Y_MAX_LIMIT)
         ]
       end
 
@@ -35,8 +36,11 @@ module Cure
       end
 
       # @param [String] range
-      def self.position_for_digit(range)
-        range.upcase.scan(/\d+/).first.to_i - 1
+      def self.position_for_digit(range, if_digit_nil: nil)
+        digit = range.upcase.scan(/\d+/).first
+        return digit.to_i - 1 if digit && digit != ""
+
+        if_digit_nil
       end
     end
   end

--- a/lib/cure/extract/csv_lookup.rb
+++ b/lib/cure/extract/csv_lookup.rb
@@ -6,14 +6,20 @@ module Cure
 
       X_MAX_LIMIT = 1_023
       Y_MAX_LIMIT = 10_000_000
-      \
+      INVALID_FORMAT_REGEX = /^(?![A-Z]{1,3}(\d+)?:[A-Z]{1,3}(\d+)?$).*/
+
       # @param [String,Integer] position - [Ex A1:B1, A1:B1, A2:B2, A:B2, A:B]
       # @return [Array] [column_start_idx, column_end_idx, row_start_idx, row_end_idx]
       def self.array_position_lookup(position)
         return [0, X_MAX_LIMIT, 0, Y_MAX_LIMIT] if position.is_a?(Integer) && position == -1 # Whole sheet
 
+        if position.upcase.match?(INVALID_FORMAT_REGEX)
+          raise ArgumentError,
+            "Invalid position format: '#{position}'. Expected format like 'A1:B10', 'A:B', 'AMJ1:C100'," \
+              "where column is 1-3 letters and row part is optional digits."
+        end
+
         start, finish, *_excess = position.split(":")
-        raise "Invalid format" unless start || finish
 
         [
           position_for_letter(start),

--- a/lib/cure/extract/variable.rb
+++ b/lib/cure/extract/variable.rb
@@ -7,8 +7,10 @@ module Cure
 
       def initialize(name, location, ref_name: "_default")
         @name = name
-        @location = [Extract::CsvLookup.position_for_letter(location),
-                     Extract::CsvLookup.position_for_digit(location)]
+        @location = [
+          Extract::CsvLookup.position_for_letter(location),
+          Extract::CsvLookup.position_for_digit(location, if_digit_nil: 1_023)
+        ]
         @ref_name = ref_name
       end
 

--- a/spec/cure/cleanup/csv_lookup_spec.rb
+++ b/spec/cure/cleanup/csv_lookup_spec.rb
@@ -18,6 +18,11 @@ RSpec.describe Cure::Extract::CsvLookup do
       arr = described_class.array_position_lookup(-1)
       expect(arr).to eq([0, 1_023, 0, 10000000])
     end
+
+    it "should handle missing digits as max values" do
+      arr = described_class.array_position_lookup("A1:B")
+      expect(arr).to eq([0, 1, 0, 10000000])
+    end
   end
 
   describe "#position_for_letter" do
@@ -32,6 +37,21 @@ RSpec.describe Cure::Extract::CsvLookup do
     it "should find position for a multi-character column" do
       arr = described_class.position_for_letter("AMJ")
       expect(arr).to eq(1023)
+    end
+  end
+
+  describe "#position_for_digit" do
+    it "should find position for a single-digit row" do
+      val = described_class.position_for_digit("1")
+      expect(val).to eq(0)
+
+      val_2 = described_class.position_for_digit("3")
+      expect(val_2).to eq(2)
+    end
+
+    it "should find position for a multi-digit row" do
+      arr = described_class.position_for_digit("100")
+      expect(arr).to eq(99)
     end
   end
 end

--- a/spec/cure/cleanup/csv_lookup_spec.rb
+++ b/spec/cure/cleanup/csv_lookup_spec.rb
@@ -31,6 +31,14 @@ RSpec.describe Cure::Extract::CsvLookup do
       arr = described_class.array_position_lookup("A:B")
       expect(arr).to eq([0, 1, 0, 10000000])
     end
+
+    it "should raise on bad formats" do
+      %w[A1:B1:1 TEST1:B1 FOO].each do |bad_format|
+        expect {
+          described_class.array_position_lookup(bad_format)
+        }.to raise_error(ArgumentError, /Invalid position format: '#{bad_format}'/)
+      end
+    end
   end
 
   describe "#position_for_letter" do

--- a/spec/cure/cleanup/csv_lookup_spec.rb
+++ b/spec/cure/cleanup/csv_lookup_spec.rb
@@ -19,8 +19,16 @@ RSpec.describe Cure::Extract::CsvLookup do
       expect(arr).to eq([0, 1_023, 0, 10000000])
     end
 
-    it "should handle missing digits as max values" do
+    it "should handle missing finish digits as max values" do
       arr = described_class.array_position_lookup("A1:B")
+      expect(arr).to eq([0, 1, 0, 10000000])
+
+      arr_2 = described_class.array_position_lookup("A:B1")
+      expect(arr_2).to eq([0, 1, 0, 0])
+    end
+
+    it "should handle missing start digits as max values" do
+      arr = described_class.array_position_lookup("A:B")
       expect(arr).to eq([0, 1, 0, 10000000])
     end
   end


### PR DESCRIPTION
can now handle a variety of different formats for named ranges. a:b1, a1:b, a100:b100 etc

will throw if bad with a nicer error message